### PR TITLE
26.1.2 Update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          21,    # Current Java LTS
+          25,    # Current Java LTS
         ]
     runs-on: ubuntu-22.04
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ matrix.java == '21' }} # Only upload artifacts built from latest java
+        if: ${{ matrix.java == '25' }} # Only upload artifacts built from latest java
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'net.fabricmc.fabric-loom-remap' version "${loom_version}"
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -16,13 +16,6 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
-
-	maven {
-		url = "https://repo.spongepowered.org/repository/maven-public/"
-	}
-
-	// Good to have for other dependencies
-	mavenCentral()
 }
 
 loom {
@@ -40,15 +33,15 @@ loom {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Change to include it so it bundles into the mod itself
 	include implementation("org.apache.commons:commons-math3:3.6.1")
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
+    	compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 	
 }
 
@@ -61,7 +54,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
@@ -70,8 +63,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {
@@ -96,8 +89,4 @@ publishing {
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
 	}
-}
-
-tasks.withType(JavaCompile).configureEach {
-	it.options.compilerArgs << ("-AoutRefMapFile=${project.buildDir}/resources/main/superfastmath.refmap.json" as String)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,15 +6,14 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.4
-loader_version=0.18.4
+minecraft_version=26.1.2
+loader_version=0.18.6
 loom_version=1.15-SNAPSHOT
 
 # Mod Properties
-mod_version=0.0.2-1.21.11
+mod_version=0.0.3-26.1.2
 maven_group=org.elias.fastmath
 archives_base_name=superfastmath
 
 # Dependencies
-fabric_version=0.141.3+1.21.11
+fabric_version=0.145.4+26.1.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/org/elias/fastmath/mixin/client/ExampleClientMixin.java
+++ b/src/client/java/org/elias/fastmath/mixin/client/ExampleClientMixin.java
@@ -1,12 +1,12 @@
 package org.elias.fastmath.mixin.client;
 
-import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(MinecraftClient.class)
+@Mixin(Minecraft.class)
 public class ExampleClientMixin {
 	@Inject(at = @At("HEAD"), method = "run")
 	private void init(CallbackInfo info) {

--- a/src/main/java/org/elias/fastmath/mixin/BlockPosMixin.java
+++ b/src/main/java/org/elias/fastmath/mixin/BlockPosMixin.java
@@ -1,13 +1,22 @@
 package org.elias.fastmath.mixin;
 
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Vec3i;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Vec3i;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(BlockPos.class)
 public abstract class BlockPosMixin extends Vec3i {
     public BlockPosMixin(int x, int y, int z) { super(x, y, z); }
+
+    @Shadow private static int X_OFFSET;
+    @Shadow private static int Z_OFFSET;
+    @Shadow public static int PACKED_HORIZONTAL_LENGTH;
+    @Shadow public static int PACKED_Y_LENGTH;
+    @Shadow private static long PACKED_X_MASK;
+    @Shadow private static long PACKED_Y_MASK;
+    @Shadow private static long PACKED_Z_MASK;
 
     /**
      * @author elias
@@ -16,9 +25,11 @@ public abstract class BlockPosMixin extends Vec3i {
      */
     @Overwrite
     public static long asLong(int x, int y, int z) {
-        return (((long)x & 0x3FFFFFFL) << 38) |
-                (((long)z & 0x3FFFFFFL) << 12) |
-                ((long)y & 0xFFFL);
+        long node = 0L;
+        node |= ((long)x & PACKED_X_MASK) << X_OFFSET;
+        node |= ((long)y & PACKED_Y_MASK);
+        node |= ((long)z & PACKED_Z_MASK) << Z_OFFSET;
+        return node;
     }
 
     /**
@@ -26,25 +37,19 @@ public abstract class BlockPosMixin extends Vec3i {
      * @reason Matches the optimized bit-layout to extract X correctly.
      */
     @Overwrite
-    public static int unpackLongX(long packedPos) {
-        return (int)(packedPos >> 38);
-    }
+    public static int getX(long packedPos) { return (int)(packedPos << 64 - X_OFFSET - PACKED_HORIZONTAL_LENGTH >> 64 - PACKED_HORIZONTAL_LENGTH); }
 
     /**
      * @author elias
      * @reason Matches the optimized bit-layout to extract Y correctly.
      */
     @Overwrite
-    public static int unpackLongY(long packedPos) {
-        return (int)(packedPos << 52 >> 52);
-    }
+    public static int getY(long packedPos) { return (int)(packedPos << 64 - PACKED_Y_LENGTH >> 64 - PACKED_Y_LENGTH); }
 
     /**
      * @author elias
      * @reason Matches the optimized bit-layout to extract Z correctly.
      */
     @Overwrite
-    public static int unpackLongZ(long packedPos) {
-        return (int)(packedPos << 26 >> 38);
-    }
+    public static int getZ(long packedPos) { return (int)(packedPos << 64 - Z_OFFSET - PACKED_HORIZONTAL_LENGTH >> 64 - PACKED_HORIZONTAL_LENGTH); }
 }

--- a/src/main/java/org/elias/fastmath/mixin/MathMixin.java
+++ b/src/main/java/org/elias/fastmath/mixin/MathMixin.java
@@ -1,11 +1,11 @@
 package org.elias.fastmath.mixin;
 
-import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.Mth;
 import org.elias.fastmath.MathUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-@Mixin(MathHelper.class)
+@Mixin(Mth.class)
 public class MathMixin {
 
 	/**
@@ -58,7 +58,7 @@ public class MathMixin {
 	 * @reason Faster hypotenuse calculation.
 	 */
 	@Overwrite
-	public static double hypot(double a, double b) {
+	public static double length(double a, double b) {
 		return Math.sqrt(a * a + b * b);
 	}
 
@@ -94,17 +94,8 @@ public class MathMixin {
 	 * @reason Fast quintic polynomial fade for Perlin noise.
 	 */
 	@Overwrite
-	public static double perlinFade(double value) {
+	public static double smoothstep(double value) {
 		return value * value * value * (value * (value * 6.0 - 15.0) + 10.0);
-	}
-
-	/**
-	 * @author elias
-	 * @reason Optimized hash for block positions.
-	 */
-	@Overwrite
-	public static long hashCode(int x, int y, int z) {
-		return MathUtil.fastPosHash(x, y, z);
 	}
 
 	/**

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,9 +29,9 @@
 		}
 	],
 	"depends": {
-		"fabricloader": ">=0.18.4",
-		"minecraft": "~1.21.11",
-		"java": ">=21",
+		"fabricloader": ">=0.18.6",
+		"minecraft": "~26.1",
+		"java": ">=25",
 		"fabric-api": "*"
 	},
 	"suggests": {


### PR DESCRIPTION
This PR updates the mod to be compatible with Minecraft 26.1.2 The main changes involve adapting to Mojang mappings (unobfuscated), which required renaming classes, methods and fields. The build system was also cleaned up to remove manual Mixin processor configuration that was causing obfuscation mapping conflicts. Couple of methods that no longer exist in this version of Minecraft were removed or replaced with their current equivalents.